### PR TITLE
fix documentation for uppercase functions

### DIFF
--- a/include/mega65/conio.h
+++ b/include/mega65/conio.h
@@ -316,7 +316,7 @@ void fastcall sethotregs(unsigned char f);
  */
 void fastcall setextendedattrib(unsigned char f);
 
-/* \m65libsummary{togglecase}{Set lower case character set}
+/* \m65libsummary{setlowercase}{Set lower case character set}
     \m65libsyntax    {void setlowercase(void)}
 */
 /**
@@ -324,7 +324,7 @@ void fastcall setextendedattrib(unsigned char f);
  */
 void fastcall setlowercase(void);
 
-/* \m65libsummary{togglecase}{Set upper case character set}
+/* \m65libsummary{setuppercase}{Set upper case character set}
     \m65libsyntax    {void setuppercase(void)}
 */
 /**


### PR DESCRIPTION
Noticed this was incorrect in the user guide;

![image](https://github.com/user-attachments/assets/d520bb7d-701e-4f7e-af3a-7bb63ec11fa6)
